### PR TITLE
Lookup tables

### DIFF
--- a/lexer/Cargo.toml
+++ b/lexer/Cargo.toml
@@ -7,4 +7,4 @@ repository = "https://github.com/paritytech/lunarity"
 description = "A high performance Solidity language Lexer"
 
 [dependencies]
-logos = { version = "0.7.6", features = ["nul_term_source"] }
+logos = { version = "0.7.7", features = ["nul_term_source"] }

--- a/lexer/Cargo.toml
+++ b/lexer/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "lunarity-lexer"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "GPL-3.0"
 repository = "https://github.com/paritytech/lunarity"
 description = "A high performance Solidity language Lexer"
 
 [dependencies]
-logos = { version = "0.6.1", features = ["nul_term_source"] }
+logos = { version = "0.7.6", features = ["nul_term_source"] }

--- a/lexer/src/lib.rs
+++ b/lexer/src/lib.rs
@@ -3,11 +3,12 @@ extern crate logos;
 mod token;
 
 pub use self::token::Token;
+pub use logos::{Logos, lookup};
 pub type Lexer<S> = logos::Lexer<Token, S>;
 
 // FIXME: This should probably be handled with a callback
 #[inline]
-pub fn read_pragma<'source, S: logos::Source<'source>>(lex: &mut Lexer<S>) -> &'source str {
+pub fn read_pragma<'source, S: logos::Source<'source>>(lex: &mut Lexer<S>) -> S::Slice {
     use logos::internal::LexerInternal;
 
     loop {

--- a/lunarity/Cargo.toml
+++ b/lunarity/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "lunarity"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "GPL-3.0"
 repository = "https://github.com/paritytech/lunarity"
 
 [dependencies]
 lunarity-ast = "0.2"
-# lunarity-lexer = "0.2"
-# lunarity-parser = "0.2"
+# lunarity-lexer = "0.2.1"
+# lunarity-parser = "0.2.1"
 lunarity-lexer = { path = "../lexer" }
 lunarity-parser = { path = "../parser" }
 

--- a/lunarity/Cargo.toml
+++ b/lunarity/Cargo.toml
@@ -7,8 +7,10 @@ repository = "https://github.com/paritytech/lunarity"
 
 [dependencies]
 lunarity-ast = "0.2"
-lunarity-lexer = "0.2"
-lunarity-parser = "0.2"
+# lunarity-lexer = "0.2"
+# lunarity-parser = "0.2"
+lunarity-lexer = { path = "../lexer" }
+lunarity-parser = { path = "../parser" }
 
 [dev-dependencies]
 toolshed = "0.6"

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -8,7 +8,7 @@ description = "A high performance Solidity language Parser"
 
 [dependencies]
 toolshed = "0.6"
-# lunarity-lexer = "0.2"
+# lunarity-lexer = "0.2.1"
 lunarity-lexer = { path = "../lexer" }
 lunarity-ast = "0.2"
 

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lunarity-parser"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "GPL-3.0"
 repository = "https://github.com/paritytech/lunarity"
@@ -8,7 +8,8 @@ description = "A high performance Solidity language Parser"
 
 [dependencies]
 toolshed = "0.6"
-lunarity-lexer = "0.2"
+# lunarity-lexer = "0.2"
+lunarity-lexer = { path = "../lexer" }
 lunarity-ast = "0.2"
 
 [dev-dependencies]

--- a/parser/src/contract.rs
+++ b/parser/src/contract.rs
@@ -1,7 +1,7 @@
 use toolshed::list::{ListBuilder, GrowableList};
 
 use ast::*;
-use {Parser, ModifierContext, TopPrecedence, RegularTypeNameContext};
+use {Parser, ModifierContext, TOP, RegularTypeNameContext};
 use lexer::Token;
 
 impl<'ast> Parser<'ast> {
@@ -70,7 +70,7 @@ impl<'ast> Parser<'ast> {
         let name = self.expect_str_node(Token::Identifier);
 
         let init = if self.allow(Token::Assign) {
-            match self.expression::<TopPrecedence>() {
+            match self.expression(TOP) {
                 None => {
                     self.error();
 

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -203,6 +203,22 @@ impl<'ast> Parser<'ast> {
     }
 
     #[inline]
+    fn node_from_slice<T, F, I, R>(&mut self, func: F) -> R
+    where
+        T: 'ast + Copy,
+        F: FnOnce(&'ast str) -> I,
+        I: Into<T>,
+        R: From<Node<'ast, T>>,
+    {
+        let slice = self.lexer.slice();
+        let (start, end) = self.loc();
+
+        self.lexer.advance();
+
+        self.node_at(start, end, func(slice))
+    }
+
+    #[inline]
     fn parse(&mut self) {
         let builder = GrowableList::new();
 

--- a/parser/src/nested.rs
+++ b/parser/src/nested.rs
@@ -2,351 +2,83 @@ use Parser;
 use lexer::{Token, Logos, lookup};
 use ast::*;
 
-type NestedHandler = Option<for<'ast> fn(&mut Parser<'ast>, ExpressionNode<'ast>) -> Option<ExpressionNode<'ast>>>;
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+pub struct Precedence(u8);
 
-pub trait Precedence {
-    const LUT: [NestedHandler; Token::SIZE];
+type HandlerFn = for<'ast> fn(&mut Parser<'ast>, ExpressionNode<'ast>) -> Option<ExpressionNode<'ast>>;
+
+#[derive(Clone, Copy)]
+struct NestedHandler(Precedence, HandlerFn);
+
+pub const TOP: Precedence = Precedence(15);
+pub const P14: Precedence = Precedence(14);
+pub const P13: Precedence = Precedence(13);
+pub const P12: Precedence = Precedence(12);
+pub const P11: Precedence = Precedence(11);
+pub const P10: Precedence = Precedence(10);
+pub const P9: Precedence = Precedence(9);
+pub const P8: Precedence = Precedence(8);
+pub const P7: Precedence = Precedence(7);
+pub const P6: Precedence = Precedence(6);
+pub const P5: Precedence = Precedence(5);
+pub const P4: Precedence = Precedence(4);
+pub const P3: Precedence = Precedence(3);
+pub const P2: Precedence = Precedence(2);
+
+const INVALID: Precedence = Precedence(100);
+
+static NESTED_LUT: [NestedHandler; Token::SIZE] = lookup! {
+    Token::Accessor               => NestedHandler(P2, MEMBER),
+    Token::ParenOpen              => NestedHandler(P2, CALL),
+    Token::BracketOpen            => NestedHandler(P2, INDEX),
+    Token::OperatorIncrement      => NestedHandler(P2, INC),
+    Token::OperatorDecrement      => NestedHandler(P2, DEC),
+    Token::OperatorExponent       => NestedHandler(P3, EXPONENT),
+    Token::OperatorMultiplication => NestedHandler(P4, MUL),
+    Token::OperatorDivision       => NestedHandler(P4, DIV),
+    Token::OperatorRemainder      => NestedHandler(P4, REMAINDER),
+    Token::OperatorAddition       => NestedHandler(P5, ADD),
+    Token::OperatorSubtraction    => NestedHandler(P5, SUB),
+    Token::OperatorBitShiftLeft   => NestedHandler(P6, BIT_SHIFT_LEFT),
+    Token::OperatorBitShiftRight  => NestedHandler(P6, BIT_SHIFT_RIGHT),
+    Token::OperatorBitAnd         => NestedHandler(P7, BIT_AND),
+    Token::OperatorBitXor         => NestedHandler(P8, BIT_XOR),
+    Token::OperatorBitOr          => NestedHandler(P9, BIT_OR),
+    Token::OperatorLesser         => NestedHandler(P10, LESSER),
+    Token::OperatorLesserEquals   => NestedHandler(P10, LESSER_EQUALITY),
+    Token::OperatorGreater        => NestedHandler(P10, GREATER),
+    Token::OperatorGreaterEquals  => NestedHandler(P10, GREATER_EQUALITY),
+    Token::OperatorEquality       => NestedHandler(P11, EQUALITY),
+    Token::OperatorInequality     => NestedHandler(P11, INEQUALITY),
+    Token::OperatorLogicalAnd     => NestedHandler(P12, LOGICAL_AND),
+    Token::OperatorLogicalOr      => NestedHandler(P13, LOGICAL_OR),
+    Token::OperatorConditional    => NestedHandler(P14, CONDITIONAL),
+    Token::Assign                 => NestedHandler(TOP, ASSIGN),
+    Token::AssignAddition         => NestedHandler(TOP, ASSIGN_ADD),
+    Token::AssignSubtraction      => NestedHandler(TOP, ASSIGN_SUB),
+    Token::AssignMultiplication   => NestedHandler(TOP, ASSIGN_MUL),
+    Token::AssignDivision         => NestedHandler(TOP, ASSIGN_DIV),
+    Token::AssignRemainder        => NestedHandler(TOP, ASSIGN_REM),
+    Token::AssignBitShiftLeft     => NestedHandler(TOP, ASSIGN_BIT_SHIFT_LEFT),
+    Token::AssignBitShiftRight    => NestedHandler(TOP, ASSIGN_BIT_SHIFT_RIGHT),
+    Token::AssignBitAnd           => NestedHandler(TOP, ASSIGN_BIT_AND),
+    Token::AssignBitXor           => NestedHandler(TOP, ASSIGN_BIT_XOR),
+    Token::AssignBitOr            => NestedHandler(TOP, ASSIGN_BIT_OR),
+    _                             => NestedHandler(INVALID, |_, _| None),
+};
+
+impl NestedHandler {
+    #[inline]
+    fn get(self, precedence: Precedence) -> Option<HandlerFn> {
+        if self.0 <= precedence {
+            Some(self.1)
+        } else {
+            None
+        }
+    }
 }
 
-pub struct TopPrecedence;
-pub struct Precedence14;
-pub struct Precedence13;
-pub struct Precedence12;
-pub struct Precedence11;
-pub struct Precedence10;
-pub struct Precedence9;
-pub struct Precedence8;
-pub struct Precedence7;
-pub struct Precedence6;
-pub struct Precedence5;
-pub struct Precedence4;
-pub struct Precedence3;
-pub struct Precedence2;
-
-impl Precedence for TopPrecedence {
-    const LUT: [NestedHandler; Token::SIZE] = lookup! {
-        Token::Accessor => MEMBR,
-        Token::ParenOpen => CALL,
-        Token::BracketOpen => INDEX,
-        Token::OperatorIncrement => INC,
-        Token::OperatorDecrement => DEC,
-        Token::OperatorMultiplication => MUL,
-        Token::OperatorDivision => DIV,
-        Token::OperatorRemainder => REM,
-        Token::OperatorExponent => EXPN,
-        Token::OperatorAddition => ADD,
-        Token::OperatorSubtraction => SUB,
-        Token::OperatorBitShiftLeft => BSL,
-        Token::OperatorBitShiftRight => BSR,
-        Token::OperatorLesser => LESS,
-        Token::OperatorLesserEquals => LSEQ,
-        Token::OperatorGreater => GRTR,
-        Token::OperatorGreaterEquals => GREQ,
-        Token::OperatorEquality => EQ,
-        Token::OperatorInequality => INEQ,
-        Token::OperatorBitAnd => B_AND,
-        Token::OperatorBitXor => B_XOR,
-        Token::OperatorBitOr => B_OR,
-        Token::OperatorLogicalAnd => AND,
-        Token::OperatorLogicalOr => OR,
-        Token::OperatorConditional => COND,
-        Token::Assign => ASGN,
-        Token::AssignAddition => A_ADD,
-        Token::AssignSubtraction => A_SUB,
-        Token::AssignMultiplication => A_MUL,
-        Token::AssignDivision => A_DIV,
-        Token::AssignRemainder => A_REM,
-        Token::AssignBitShiftLeft => A_BSL,
-        Token::AssignBitShiftRight => A_BSR,
-        Token::AssignBitAnd => A_BAN,
-        Token::AssignBitXor => A_XOR,
-        Token::AssignBitOr => A_BOR,
-        _ => None,
-    };
-}
-
-impl Precedence for Precedence14 {
-    const LUT: [NestedHandler; Token::SIZE] = lookup! {
-        Token::Accessor => MEMBR,
-        Token::ParenOpen => CALL,
-        Token::BracketOpen => INDEX,
-        Token::OperatorIncrement => INC,
-        Token::OperatorDecrement => DEC,
-        Token::OperatorMultiplication => MUL,
-        Token::OperatorDivision => DIV,
-        Token::OperatorRemainder => REM,
-        Token::OperatorExponent => EXPN,
-        Token::OperatorAddition => ADD,
-        Token::OperatorSubtraction => SUB,
-        Token::OperatorBitShiftLeft => BSL,
-        Token::OperatorBitShiftRight => BSR,
-        Token::OperatorLesser => LESS,
-        Token::OperatorLesserEquals => LSEQ,
-        Token::OperatorGreater => GRTR,
-        Token::OperatorGreaterEquals => GREQ,
-        Token::OperatorEquality => EQ,
-        Token::OperatorInequality => INEQ,
-        Token::OperatorBitAnd => B_AND,
-        Token::OperatorBitXor => B_XOR,
-        Token::OperatorBitOr => B_OR,
-        Token::OperatorLogicalAnd => AND,
-        Token::OperatorLogicalOr => OR,
-        Token::OperatorConditional => COND,
-        _ => None,
-    };
-}
-
-impl Precedence for Precedence13 {
-    const LUT: [NestedHandler; Token::SIZE] = lookup! {
-        Token::Accessor => MEMBR,
-        Token::ParenOpen => CALL,
-        Token::BracketOpen => INDEX,
-        Token::OperatorIncrement => INC,
-        Token::OperatorDecrement => DEC,
-        Token::OperatorMultiplication => MUL,
-        Token::OperatorDivision => DIV,
-        Token::OperatorRemainder => REM,
-        Token::OperatorExponent => EXPN,
-        Token::OperatorAddition => ADD,
-        Token::OperatorSubtraction => SUB,
-        Token::OperatorBitShiftLeft => BSL,
-        Token::OperatorBitShiftRight => BSR,
-        Token::OperatorLesser => LESS,
-        Token::OperatorLesserEquals => LSEQ,
-        Token::OperatorGreater => GRTR,
-        Token::OperatorGreaterEquals => GREQ,
-        Token::OperatorEquality => EQ,
-        Token::OperatorInequality => INEQ,
-        Token::OperatorBitAnd => B_AND,
-        Token::OperatorBitXor => B_XOR,
-        Token::OperatorBitOr => B_OR,
-        Token::OperatorLogicalAnd => AND,
-        Token::OperatorLogicalOr => OR,
-        _ => None,
-    };
-}
-
-impl Precedence for Precedence12 {
-    const LUT: [NestedHandler; Token::SIZE] = lookup! {
-        Token::Accessor => MEMBR,
-        Token::ParenOpen => CALL,
-        Token::BracketOpen => INDEX,
-        Token::OperatorIncrement => INC,
-        Token::OperatorDecrement => DEC,
-        Token::OperatorMultiplication => MUL,
-        Token::OperatorDivision => DIV,
-        Token::OperatorRemainder => REM,
-        Token::OperatorExponent => EXPN,
-        Token::OperatorAddition => ADD,
-        Token::OperatorSubtraction => SUB,
-        Token::OperatorBitShiftLeft => BSL,
-        Token::OperatorBitShiftRight => BSR,
-        Token::OperatorLesser => LESS,
-        Token::OperatorLesserEquals => LSEQ,
-        Token::OperatorGreater => GRTR,
-        Token::OperatorGreaterEquals => GREQ,
-        Token::OperatorEquality => EQ,
-        Token::OperatorInequality => INEQ,
-        Token::OperatorBitAnd => B_AND,
-        Token::OperatorBitXor => B_XOR,
-        Token::OperatorBitOr => B_OR,
-        Token::OperatorLogicalAnd => AND,
-        _ => None,
-    };
-}
-
-impl Precedence for Precedence11 {
-    const LUT: [NestedHandler; Token::SIZE] = lookup! {
-        Token::Accessor => MEMBR,
-        Token::ParenOpen => CALL,
-        Token::BracketOpen => INDEX,
-        Token::OperatorIncrement => INC,
-        Token::OperatorDecrement => DEC,
-        Token::OperatorMultiplication => MUL,
-        Token::OperatorDivision => DIV,
-        Token::OperatorRemainder => REM,
-        Token::OperatorExponent => EXPN,
-        Token::OperatorAddition => ADD,
-        Token::OperatorSubtraction => SUB,
-        Token::OperatorBitShiftLeft => BSL,
-        Token::OperatorBitShiftRight => BSR,
-        Token::OperatorLesser => LESS,
-        Token::OperatorLesserEquals => LSEQ,
-        Token::OperatorGreater => GRTR,
-        Token::OperatorGreaterEquals => GREQ,
-        Token::OperatorEquality => EQ,
-        Token::OperatorInequality => INEQ,
-        Token::OperatorBitAnd => B_AND,
-        Token::OperatorBitXor => B_XOR,
-        Token::OperatorBitOr => B_OR,
-        _ => None,
-    };
-}
-
-impl Precedence for Precedence10 {
-    const LUT: [NestedHandler; Token::SIZE] = lookup! {
-        Token::Accessor => MEMBR,
-        Token::ParenOpen => CALL,
-        Token::BracketOpen => INDEX,
-        Token::OperatorIncrement => INC,
-        Token::OperatorDecrement => DEC,
-        Token::OperatorMultiplication => MUL,
-        Token::OperatorDivision => DIV,
-        Token::OperatorRemainder => REM,
-        Token::OperatorExponent => EXPN,
-        Token::OperatorAddition => ADD,
-        Token::OperatorSubtraction => SUB,
-        Token::OperatorBitShiftLeft => BSL,
-        Token::OperatorBitShiftRight => BSR,
-        Token::OperatorLesser => LESS,
-        Token::OperatorLesserEquals => LSEQ,
-        Token::OperatorGreater => GRTR,
-        Token::OperatorGreaterEquals => GREQ,
-        Token::OperatorBitAnd => B_AND,
-        Token::OperatorBitXor => B_XOR,
-        Token::OperatorBitOr => B_OR,
-        _ => None,
-    };
-}
-
-impl Precedence for Precedence9 {
-    const LUT: [NestedHandler; Token::SIZE] = lookup! {
-        Token::Accessor => MEMBR,
-        Token::ParenOpen => CALL,
-        Token::BracketOpen => INDEX,
-        Token::OperatorIncrement => INC,
-        Token::OperatorDecrement => DEC,
-        Token::OperatorMultiplication => MUL,
-        Token::OperatorDivision => DIV,
-        Token::OperatorRemainder => REM,
-        Token::OperatorExponent => EXPN,
-        Token::OperatorAddition => ADD,
-        Token::OperatorSubtraction => SUB,
-        Token::OperatorBitShiftLeft => BSL,
-        Token::OperatorBitShiftRight => BSR,
-        Token::OperatorBitAnd => B_AND,
-        Token::OperatorBitXor => B_XOR,
-        Token::OperatorBitOr => B_OR,
-        _ => None,
-    };
-}
-
-impl Precedence for Precedence8 {
-    const LUT: [NestedHandler; Token::SIZE] = lookup! {
-        Token::Accessor => MEMBR,
-        Token::ParenOpen => CALL,
-        Token::BracketOpen => INDEX,
-        Token::OperatorIncrement => INC,
-        Token::OperatorDecrement => DEC,
-        Token::OperatorMultiplication => MUL,
-        Token::OperatorDivision => DIV,
-        Token::OperatorRemainder => REM,
-        Token::OperatorExponent => EXPN,
-        Token::OperatorAddition => ADD,
-        Token::OperatorSubtraction => SUB,
-        Token::OperatorBitShiftLeft => BSL,
-        Token::OperatorBitShiftRight => BSR,
-        Token::OperatorBitAnd => B_AND,
-        Token::OperatorBitXor => B_XOR,
-        _ => None,
-    };
-}
-
-impl Precedence for Precedence7 {
-    const LUT: [NestedHandler; Token::SIZE] = lookup! {
-        Token::Accessor => MEMBR,
-        Token::ParenOpen => CALL,
-        Token::BracketOpen => INDEX,
-        Token::OperatorIncrement => INC,
-        Token::OperatorDecrement => DEC,
-        Token::OperatorMultiplication => MUL,
-        Token::OperatorDivision => DIV,
-        Token::OperatorRemainder => REM,
-        Token::OperatorExponent => EXPN,
-        Token::OperatorAddition => ADD,
-        Token::OperatorSubtraction => SUB,
-        Token::OperatorBitShiftLeft => BSL,
-        Token::OperatorBitShiftRight => BSR,
-        Token::OperatorBitAnd => B_AND,
-        _ => None,
-    };
-}
-
-impl Precedence for Precedence6 {
-    const LUT: [NestedHandler; Token::SIZE] = lookup! {
-        Token::Accessor => MEMBR,
-        Token::ParenOpen => CALL,
-        Token::BracketOpen => INDEX,
-        Token::OperatorIncrement => INC,
-        Token::OperatorDecrement => DEC,
-        Token::OperatorMultiplication => MUL,
-        Token::OperatorDivision => DIV,
-        Token::OperatorRemainder => REM,
-        Token::OperatorExponent => EXPN,
-        Token::OperatorAddition => ADD,
-        Token::OperatorSubtraction => SUB,
-        Token::OperatorBitShiftLeft => BSL,
-        Token::OperatorBitShiftRight => BSR,
-        _ => None,
-    };
-}
-
-impl Precedence for Precedence5 {
-    const LUT: [NestedHandler; Token::SIZE] = lookup! {
-        Token::Accessor => MEMBR,
-        Token::ParenOpen => CALL,
-        Token::BracketOpen => INDEX,
-        Token::OperatorIncrement => INC,
-        Token::OperatorDecrement => DEC,
-        Token::OperatorMultiplication => MUL,
-        Token::OperatorDivision => DIV,
-        Token::OperatorRemainder => REM,
-        Token::OperatorExponent => EXPN,
-        Token::OperatorAddition => ADD,
-        Token::OperatorSubtraction => SUB,
-        _ => None,
-    };
-}
-
-impl Precedence for Precedence4 {
-    const LUT: [NestedHandler; Token::SIZE] = lookup! {
-        Token::Accessor => MEMBR,
-        Token::ParenOpen => CALL,
-        Token::BracketOpen => INDEX,
-        Token::OperatorIncrement => INC,
-        Token::OperatorDecrement => DEC,
-        Token::OperatorMultiplication => MUL,
-        Token::OperatorDivision => DIV,
-        Token::OperatorRemainder => REM,
-        Token::OperatorExponent => EXPN,
-        _ => None,
-    };
-}
-
-impl Precedence for Precedence3 {
-    const LUT: [NestedHandler; Token::SIZE] = lookup! {
-        Token::Accessor => MEMBR,
-        Token::ParenOpen => CALL,
-        Token::BracketOpen => INDEX,
-        Token::OperatorIncrement => INC,
-        Token::OperatorDecrement => DEC,
-        Token::OperatorExponent => EXPN,
-        _ => None,
-    };
-}
-
-impl Precedence for Precedence2 {
-    const LUT: [NestedHandler; Token::SIZE] = lookup! {
-        Token::Accessor => MEMBR,
-        Token::ParenOpen => CALL,
-        Token::BracketOpen => INDEX,
-        Token::OperatorIncrement => INC,
-        Token::OperatorDecrement => DEC,
-        _ => None,
-    };
-}
-
-const CALL: NestedHandler = Some(|par, callee| {
+const CALL: HandlerFn = |par, callee| {
     par.lexer.advance();
 
     let arguments = par.expression_list();
@@ -356,9 +88,9 @@ const CALL: NestedHandler = Some(|par, callee| {
         callee,
         arguments,
     })
-});
+};
 
-const MEMBR: NestedHandler = Some(|par, object| {
+const MEMBER: HandlerFn = |par, object| {
     par.lexer.advance();
 
     let member = par.expect_str_node(Token::Identifier);
@@ -367,137 +99,123 @@ const MEMBR: NestedHandler = Some(|par, object| {
         object,
         member,
     })
-});
+};
 
-const INDEX: NestedHandler = Some(|par, array| {
+const INDEX: HandlerFn = |par, array| {
     par.lexer.advance();
 
-    let index = par.expression::<TopPrecedence>();
+    let index = par.expression(TOP);
     let end   = par.expect_end(Token::BracketClose);
 
     par.node_at(array.start, end, IndexAccessExpression {
         array,
         index,
     })
-});
+};
 
-const INC: NestedHandler = Some(|par, operand| {
+const INC: HandlerFn = |par, operand| {
     let operator: Node<_> = par.node_at_token(PostfixOperator::Increment);
 
     par.node_at(operand.start, operator.end, PostfixExpression {
         operator,
         operand,
     })
-});
+};
 
-const DEC: NestedHandler = Some(|par, operand| {
+const DEC: HandlerFn = |par, operand| {
     let operator: Node<_> = par.node_at_token(PostfixOperator::Decrement);
 
     par.node_at(operand.start, operator.end, PostfixExpression {
         operator,
         operand,
     })
-});
+};
 
-const COND: NestedHandler = Some(|par, test| {
+const CONDITIONAL: HandlerFn = |par, test| {
     par.lexer.advance();
 
-    let consequent = expect!(par, par.expression::<Precedence14>());
+    let consequent = expect!(par, par.expression(P14));
 
     par.expect(Token::Colon);
 
-    let alternate = expect!(par, par.expression::<Precedence14>());
+    let alternate = expect!(par, par.expression(P14));
 
     par.node_at(test.start, alternate.end, ConditionalExpression {
         test,
         consequent,
         alternate,
     })
-});
-
+};
 
 macro_rules! assign {
     ($name:ident => $op:ident) => {
-        const $name: NestedHandler = {
-            fn handler<'ast>(par: &mut Parser<'ast>, left: ExpressionNode<'ast>) -> Option<ExpressionNode<'ast>> {
-                // TODO: check if left is LValue
+        const $name: HandlerFn = |par, left| {
+            // TODO: check if left is LValue
 
-                let operator = par.node_at_token(AssignmentOperator::$op);
-                let right    = expect!(par, par.expression::<TopPrecedence>());
+            let operator = par.node_at_token(AssignmentOperator::$op);
+            let right    = expect!(par, par.expression(TOP));
 
-                par.node_at(left.start, right.end, AssignmentExpression {
-                    operator,
-                    left,
-                    right,
-                })
-            }
-
-            Some(handler)
+            par.node_at(left.start, right.end, AssignmentExpression {
+                operator,
+                left,
+                right,
+            })
         };
     }
 }
 
 macro_rules! binary {
     ($name:ident, $precedence:ident => $op:ident) => {
-        const $name: NestedHandler = {
-            fn handler<'ast>(par: &mut Parser<'ast>, left: ExpressionNode<'ast>) -> Option<ExpressionNode<'ast>> {
-                let operator = par.node_at_token(BinaryOperator::$op);
-                let right    = expect!(par, par.expression::<$precedence>());
+        const $name: HandlerFn = |par, left| {
+            let operator = par.node_at_token(BinaryOperator::$op);
+            let right    = expect!(par, par.expression($precedence));
 
-                par.node_at(left.start, right.end, BinaryExpression {
-                    operator,
-                    left,
-                    right,
-                })
-            }
-
-            Some(handler)
+            par.node_at(left.start, right.end, BinaryExpression {
+                operator,
+                left,
+                right,
+            })
         };
     }
 }
 
-assign!(ASGN  => Plain);
-assign!(A_ADD => Addition);
-assign!(A_SUB => Subtraction);
-assign!(A_MUL => Multiplication);
-assign!(A_DIV => Division);
-assign!(A_REM => Remainder);
-assign!(A_BSL => BitShiftLeft);
-assign!(A_BSR => BitShiftRight);
-assign!(A_BAN => BitAnd);
-assign!(A_XOR => BitXor);
-assign!(A_BOR => BitOr);
+assign!(ASSIGN  => Plain);
+assign!(ASSIGN_ADD => Addition);
+assign!(ASSIGN_SUB => Subtraction);
+assign!(ASSIGN_MUL => Multiplication);
+assign!(ASSIGN_DIV => Division);
+assign!(ASSIGN_REM => Remainder);
+assign!(ASSIGN_BIT_SHIFT_LEFT => BitShiftLeft);
+assign!(ASSIGN_BIT_SHIFT_RIGHT => BitShiftRight);
+assign!(ASSIGN_BIT_AND => BitAnd);
+assign!(ASSIGN_BIT_XOR => BitXor);
+assign!(ASSIGN_BIT_OR => BitOr);
 
-binary!(OR    , Precedence13 => LogicalOr);
-binary!(AND   , Precedence12 => LogicalAnd);
-binary!(EQ    , Precedence11 => Equality);
-binary!(INEQ  , Precedence11 => Inequality);
-binary!(LESS  , Precedence10 => Lesser);
-binary!(LSEQ  , Precedence10 => LesserEquals);
-binary!(GRTR  , Precedence10 => Greater);
-binary!(GREQ  , Precedence10 => GreaterEquals);
-binary!(B_OR  , Precedence9  => BitOr);
-binary!(B_XOR , Precedence8  => BitXor);
-binary!(B_AND , Precedence7  => BitAnd);
-binary!(BSL   , Precedence6  => BitShiftLeft);
-binary!(BSR   , Precedence6  => BitShiftRight);
-binary!(ADD   , Precedence5  => Addition);
-binary!(SUB   , Precedence5  => Subtraction);
-binary!(MUL   , Precedence4  => Multiplication);
-binary!(DIV   , Precedence4  => Division);
-binary!(REM   , Precedence4  => Remainder);
-binary!(EXPN  , Precedence3  => Exponent);
+binary!(LOGICAL_OR    , P13 => LogicalOr);
+binary!(LOGICAL_AND   , P12 => LogicalAnd);
+binary!(EQUALITY    , P11 => Equality);
+binary!(INEQUALITY  , P11 => Inequality);
+binary!(LESSER  , P10 => Lesser);
+binary!(LESSER_EQUALITY  , P10 => LesserEquals);
+binary!(GREATER  , P10 => Greater);
+binary!(GREATER_EQUALITY  , P10 => GreaterEquals);
+binary!(BIT_OR  , P9  => BitOr);
+binary!(BIT_XOR , P8  => BitXor);
+binary!(BIT_AND , P7  => BitAnd);
+binary!(BIT_SHIFT_LEFT   , P6  => BitShiftLeft);
+binary!(BIT_SHIFT_RIGHT   , P6  => BitShiftRight);
+binary!(ADD   , P5  => Addition);
+binary!(SUB   , P5  => Subtraction);
+binary!(MUL   , P4  => Multiplication);
+binary!(DIV   , P4  => Division);
+binary!(REMAINDER   , P4  => Remainder);
+binary!(EXPONENT  , P3  => Exponent);
 
 
 impl<'ast> Parser<'ast> {
     #[inline]
-    pub fn nested_expression<P>(&mut self, mut left: ExpressionNode<'ast>) -> ExpressionNode<'ast>
-    where
-        P: Precedence,
-    {
-        // static LUT: [NestedHandler; Token::SIZE] = P::LUT;
-
-        while let Some(node) = P::LUT[self.lexer.token as usize].and_then(|handler| handler(self, left)) {
+    pub fn nested_expression(&mut self, mut left: ExpressionNode<'ast>, precedence: Precedence) -> ExpressionNode<'ast> {
+        while let Some(node) = NESTED_LUT[self.lexer.token as usize].get(precedence).and_then(|handler| handler(self, left)) {
             left = node;
         }
 

--- a/parser/src/nested.rs
+++ b/parser/src/nested.rs
@@ -1,249 +1,350 @@
 use Parser;
-use lexer::Token;
+use lexer::{Token, Logos, lookup};
 use ast::*;
-
-const TOTAL_TOKENS: usize = 122;
 
 type NestedHandler = Option<for<'ast> fn(&mut Parser<'ast>, ExpressionNode<'ast>) -> Option<ExpressionNode<'ast>>>;
 
 pub trait Precedence {
-    const LUT: [NestedHandler; TOTAL_TOKENS];
-
-    #[inline]
-    fn get_handler(token: Token) -> NestedHandler {
-        Self::LUT[token as usize]
-    }
+    const LUT: [NestedHandler; Token::SIZE];
 }
 
-macro_rules! precedence {
-    ($name:ident, $table:tt) => {
-        pub struct $name;
+pub struct TopPrecedence;
+pub struct Precedence14;
+pub struct Precedence13;
+pub struct Precedence12;
+pub struct Precedence11;
+pub struct Precedence10;
+pub struct Precedence9;
+pub struct Precedence8;
+pub struct Precedence7;
+pub struct Precedence6;
+pub struct Precedence5;
+pub struct Precedence4;
+pub struct Precedence3;
+pub struct Precedence2;
 
-        impl Precedence for $name {
-            const LUT: [NestedHandler; TOTAL_TOKENS] = $table;
-        }
-    }
+impl Precedence for TopPrecedence {
+    const LUT: [NestedHandler; Token::SIZE] = lookup! {
+        Token::Accessor => MEMBR,
+        Token::ParenOpen => CALL,
+        Token::BracketOpen => INDEX,
+        Token::OperatorIncrement => INC,
+        Token::OperatorDecrement => DEC,
+        Token::OperatorMultiplication => MUL,
+        Token::OperatorDivision => DIV,
+        Token::OperatorRemainder => REM,
+        Token::OperatorExponent => EXPN,
+        Token::OperatorAddition => ADD,
+        Token::OperatorSubtraction => SUB,
+        Token::OperatorBitShiftLeft => BSL,
+        Token::OperatorBitShiftRight => BSR,
+        Token::OperatorLesser => LESS,
+        Token::OperatorLesserEquals => LSEQ,
+        Token::OperatorGreater => GRTR,
+        Token::OperatorGreaterEquals => GREQ,
+        Token::OperatorEquality => EQ,
+        Token::OperatorInequality => INEQ,
+        Token::OperatorBitAnd => B_AND,
+        Token::OperatorBitXor => B_XOR,
+        Token::OperatorBitOr => B_OR,
+        Token::OperatorLogicalAnd => AND,
+        Token::OperatorLogicalOr => OR,
+        Token::OperatorConditional => COND,
+        Token::Assign => ASGN,
+        Token::AssignAddition => A_ADD,
+        Token::AssignSubtraction => A_SUB,
+        Token::AssignMultiplication => A_MUL,
+        Token::AssignDivision => A_DIV,
+        Token::AssignRemainder => A_REM,
+        Token::AssignBitShiftLeft => A_BSL,
+        Token::AssignBitShiftRight => A_BSR,
+        Token::AssignBitAnd => A_BAN,
+        Token::AssignBitXor => A_XOR,
+        Token::AssignBitOr => A_BOR,
+        _ => None,
+    };
 }
 
-precedence!(TopPrecedence, [
-    _____, _____, _____, _____, MEMBR, CALL,  _____, _____, _____, INDEX, _____, _____,
-//  EOF    ;      :      ,      .      (      )      {      }      [      ]      =>
+impl Precedence for Precedence14 {
+    const LUT: [NestedHandler; Token::SIZE] = lookup! {
+        Token::Accessor => MEMBR,
+        Token::ParenOpen => CALL,
+        Token::BracketOpen => INDEX,
+        Token::OperatorIncrement => INC,
+        Token::OperatorDecrement => DEC,
+        Token::OperatorMultiplication => MUL,
+        Token::OperatorDivision => DIV,
+        Token::OperatorRemainder => REM,
+        Token::OperatorExponent => EXPN,
+        Token::OperatorAddition => ADD,
+        Token::OperatorSubtraction => SUB,
+        Token::OperatorBitShiftLeft => BSL,
+        Token::OperatorBitShiftRight => BSR,
+        Token::OperatorLesser => LESS,
+        Token::OperatorLesserEquals => LSEQ,
+        Token::OperatorGreater => GRTR,
+        Token::OperatorGreaterEquals => GREQ,
+        Token::OperatorEquality => EQ,
+        Token::OperatorInequality => INEQ,
+        Token::OperatorBitAnd => B_AND,
+        Token::OperatorBitXor => B_XOR,
+        Token::OperatorBitOr => B_OR,
+        Token::OperatorLogicalAnd => AND,
+        Token::OperatorLogicalOr => OR,
+        Token::OperatorConditional => COND,
+        _ => None,
+    };
+}
 
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-//  IDENT  BLTIN  CONTR  LIB    IFACE  ENUM   STRUCT MODIF  EVENT  FUNCT  VAR    ANON
+impl Precedence for Precedence13 {
+    const LUT: [NestedHandler; Token::SIZE] = lookup! {
+        Token::Accessor => MEMBR,
+        Token::ParenOpen => CALL,
+        Token::BracketOpen => INDEX,
+        Token::OperatorIncrement => INC,
+        Token::OperatorDecrement => DEC,
+        Token::OperatorMultiplication => MUL,
+        Token::OperatorDivision => DIV,
+        Token::OperatorRemainder => REM,
+        Token::OperatorExponent => EXPN,
+        Token::OperatorAddition => ADD,
+        Token::OperatorSubtraction => SUB,
+        Token::OperatorBitShiftLeft => BSL,
+        Token::OperatorBitShiftRight => BSR,
+        Token::OperatorLesser => LESS,
+        Token::OperatorLesserEquals => LSEQ,
+        Token::OperatorGreater => GRTR,
+        Token::OperatorGreaterEquals => GREQ,
+        Token::OperatorEquality => EQ,
+        Token::OperatorInequality => INEQ,
+        Token::OperatorBitAnd => B_AND,
+        Token::OperatorBitXor => B_XOR,
+        Token::OperatorBitOr => B_OR,
+        Token::OperatorLogicalAnd => AND,
+        Token::OperatorLogicalOr => OR,
+        _ => None,
+    };
+}
 
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-//  AS     ASM    BREAK  CONST  CONTIN DO     DELETE ELSE   EXTERN FOR    HEX    IF
+impl Precedence for Precedence12 {
+    const LUT: [NestedHandler; Token::SIZE] = lookup! {
+        Token::Accessor => MEMBR,
+        Token::ParenOpen => CALL,
+        Token::BracketOpen => INDEX,
+        Token::OperatorIncrement => INC,
+        Token::OperatorDecrement => DEC,
+        Token::OperatorMultiplication => MUL,
+        Token::OperatorDivision => DIV,
+        Token::OperatorRemainder => REM,
+        Token::OperatorExponent => EXPN,
+        Token::OperatorAddition => ADD,
+        Token::OperatorSubtraction => SUB,
+        Token::OperatorBitShiftLeft => BSL,
+        Token::OperatorBitShiftRight => BSR,
+        Token::OperatorLesser => LESS,
+        Token::OperatorLesserEquals => LSEQ,
+        Token::OperatorGreater => GRTR,
+        Token::OperatorGreaterEquals => GREQ,
+        Token::OperatorEquality => EQ,
+        Token::OperatorInequality => INEQ,
+        Token::OperatorBitAnd => B_AND,
+        Token::OperatorBitXor => B_XOR,
+        Token::OperatorBitOr => B_OR,
+        Token::OperatorLogicalAnd => AND,
+        _ => None,
+    };
+}
 
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-//  INDEX  INTERN IMPORT IS     MAP    MEM    NEW    PAY    PULIC  PRAGMA PRIV   PURE
+impl Precedence for Precedence11 {
+    const LUT: [NestedHandler; Token::SIZE] = lookup! {
+        Token::Accessor => MEMBR,
+        Token::ParenOpen => CALL,
+        Token::BracketOpen => INDEX,
+        Token::OperatorIncrement => INC,
+        Token::OperatorDecrement => DEC,
+        Token::OperatorMultiplication => MUL,
+        Token::OperatorDivision => DIV,
+        Token::OperatorRemainder => REM,
+        Token::OperatorExponent => EXPN,
+        Token::OperatorAddition => ADD,
+        Token::OperatorSubtraction => SUB,
+        Token::OperatorBitShiftLeft => BSL,
+        Token::OperatorBitShiftRight => BSR,
+        Token::OperatorLesser => LESS,
+        Token::OperatorLesserEquals => LSEQ,
+        Token::OperatorGreater => GRTR,
+        Token::OperatorGreaterEquals => GREQ,
+        Token::OperatorEquality => EQ,
+        Token::OperatorInequality => INEQ,
+        Token::OperatorBitAnd => B_AND,
+        Token::OperatorBitXor => B_XOR,
+        Token::OperatorBitOr => B_OR,
+        _ => None,
+    };
+}
 
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-//  RET    RETNS  STORAG SUPER  THIS   THROW  USING  VIEW   WHILE  RESERV T_BOOL T_ADDR
+impl Precedence for Precedence10 {
+    const LUT: [NestedHandler; Token::SIZE] = lookup! {
+        Token::Accessor => MEMBR,
+        Token::ParenOpen => CALL,
+        Token::BracketOpen => INDEX,
+        Token::OperatorIncrement => INC,
+        Token::OperatorDecrement => DEC,
+        Token::OperatorMultiplication => MUL,
+        Token::OperatorDivision => DIV,
+        Token::OperatorRemainder => REM,
+        Token::OperatorExponent => EXPN,
+        Token::OperatorAddition => ADD,
+        Token::OperatorSubtraction => SUB,
+        Token::OperatorBitShiftLeft => BSL,
+        Token::OperatorBitShiftRight => BSR,
+        Token::OperatorLesser => LESS,
+        Token::OperatorLesserEquals => LSEQ,
+        Token::OperatorGreater => GRTR,
+        Token::OperatorGreaterEquals => GREQ,
+        Token::OperatorBitAnd => B_AND,
+        Token::OperatorBitXor => B_XOR,
+        Token::OperatorBitOr => B_OR,
+        _ => None,
+    };
+}
 
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-//  T_STR  T_BYT  T_BYTS T_INT  T_UINT T_FIX  T_UFIX L_TRUE L_FALS L_HEX  L_INT  L_RAT
+impl Precedence for Precedence9 {
+    const LUT: [NestedHandler; Token::SIZE] = lookup! {
+        Token::Accessor => MEMBR,
+        Token::ParenOpen => CALL,
+        Token::BracketOpen => INDEX,
+        Token::OperatorIncrement => INC,
+        Token::OperatorDecrement => DEC,
+        Token::OperatorMultiplication => MUL,
+        Token::OperatorDivision => DIV,
+        Token::OperatorRemainder => REM,
+        Token::OperatorExponent => EXPN,
+        Token::OperatorAddition => ADD,
+        Token::OperatorSubtraction => SUB,
+        Token::OperatorBitShiftLeft => BSL,
+        Token::OperatorBitShiftRight => BSR,
+        Token::OperatorBitAnd => B_AND,
+        Token::OperatorBitXor => B_XOR,
+        Token::OperatorBitOr => B_OR,
+        _ => None,
+    };
+}
 
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-//  L_STR  E_ETH  E_FINN E_SZAB E_WEI  T_YEAR T_WEEK T_DAYS T_HOUR T_MIN  T_SEC  :=
+impl Precedence for Precedence8 {
+    const LUT: [NestedHandler; Token::SIZE] = lookup! {
+        Token::Accessor => MEMBR,
+        Token::ParenOpen => CALL,
+        Token::BracketOpen => INDEX,
+        Token::OperatorIncrement => INC,
+        Token::OperatorDecrement => DEC,
+        Token::OperatorMultiplication => MUL,
+        Token::OperatorDivision => DIV,
+        Token::OperatorRemainder => REM,
+        Token::OperatorExponent => EXPN,
+        Token::OperatorAddition => ADD,
+        Token::OperatorSubtraction => SUB,
+        Token::OperatorBitShiftLeft => BSL,
+        Token::OperatorBitShiftRight => BSR,
+        Token::OperatorBitAnd => B_AND,
+        Token::OperatorBitXor => B_XOR,
+        _ => None,
+    };
+}
 
-    _____, INC,   DEC,   _____, _____, MUL,   DIV,   REM,   EXPN,  ADD,   SUB,   BSL,
-//  =:     ++     --     !      ~      *      /      %      **     +      -      <<
+impl Precedence for Precedence7 {
+    const LUT: [NestedHandler; Token::SIZE] = lookup! {
+        Token::Accessor => MEMBR,
+        Token::ParenOpen => CALL,
+        Token::BracketOpen => INDEX,
+        Token::OperatorIncrement => INC,
+        Token::OperatorDecrement => DEC,
+        Token::OperatorMultiplication => MUL,
+        Token::OperatorDivision => DIV,
+        Token::OperatorRemainder => REM,
+        Token::OperatorExponent => EXPN,
+        Token::OperatorAddition => ADD,
+        Token::OperatorSubtraction => SUB,
+        Token::OperatorBitShiftLeft => BSL,
+        Token::OperatorBitShiftRight => BSR,
+        Token::OperatorBitAnd => B_AND,
+        _ => None,
+    };
+}
 
-    BSR,   LESS,  LSEQ,  GRTR,  GREQ,  EQ,    INEQ,  B_AND, B_XOR, B_OR,  AND,   OR,
-//  >>     <      <=     >      >=     ==     !=     &      ^      |      &&     ||
+impl Precedence for Precedence6 {
+    const LUT: [NestedHandler; Token::SIZE] = lookup! {
+        Token::Accessor => MEMBR,
+        Token::ParenOpen => CALL,
+        Token::BracketOpen => INDEX,
+        Token::OperatorIncrement => INC,
+        Token::OperatorDecrement => DEC,
+        Token::OperatorMultiplication => MUL,
+        Token::OperatorDivision => DIV,
+        Token::OperatorRemainder => REM,
+        Token::OperatorExponent => EXPN,
+        Token::OperatorAddition => ADD,
+        Token::OperatorSubtraction => SUB,
+        Token::OperatorBitShiftLeft => BSL,
+        Token::OperatorBitShiftRight => BSR,
+        _ => None,
+    };
+}
 
-    COND,  ASGN,  A_ADD, A_SUB, A_MUL, A_DIV, A_REM, A_BSL, A_BSR, A_BAN, A_XOR, A_BOR,
-//  ?      =      +=     -=     *=     /=     %=     <<=    >>=    &=     ^=     |=
+impl Precedence for Precedence5 {
+    const LUT: [NestedHandler; Token::SIZE] = lookup! {
+        Token::Accessor => MEMBR,
+        Token::ParenOpen => CALL,
+        Token::BracketOpen => INDEX,
+        Token::OperatorIncrement => INC,
+        Token::OperatorDecrement => DEC,
+        Token::OperatorMultiplication => MUL,
+        Token::OperatorDivision => DIV,
+        Token::OperatorRemainder => REM,
+        Token::OperatorExponent => EXPN,
+        Token::OperatorAddition => ADD,
+        Token::OperatorSubtraction => SUB,
+        _ => None,
+    };
+}
 
-    _____, _____,
-//  ERRTOK ERREOF
-]);
+impl Precedence for Precedence4 {
+    const LUT: [NestedHandler; Token::SIZE] = lookup! {
+        Token::Accessor => MEMBR,
+        Token::ParenOpen => CALL,
+        Token::BracketOpen => INDEX,
+        Token::OperatorIncrement => INC,
+        Token::OperatorDecrement => DEC,
+        Token::OperatorMultiplication => MUL,
+        Token::OperatorDivision => DIV,
+        Token::OperatorRemainder => REM,
+        Token::OperatorExponent => EXPN,
+        _ => None,
+    };
+}
 
-precedence!(Precedence14, [
-    _____, _____, _____, _____, MEMBR, CALL,  _____, _____, _____, INDEX, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, INC,   DEC,   _____, _____, MUL,   DIV,   REM,   EXPN,  ADD,   SUB,   BSL,
-    BSR,   LESS,  LSEQ,  GRTR,  GREQ,  EQ,    INEQ,  B_AND, B_XOR, B_OR,  AND,   OR,
-    COND,  _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____,
-]);
+impl Precedence for Precedence3 {
+    const LUT: [NestedHandler; Token::SIZE] = lookup! {
+        Token::Accessor => MEMBR,
+        Token::ParenOpen => CALL,
+        Token::BracketOpen => INDEX,
+        Token::OperatorIncrement => INC,
+        Token::OperatorDecrement => DEC,
+        Token::OperatorExponent => EXPN,
+        _ => None,
+    };
+}
 
-precedence!(Precedence13, [
-    _____, _____, _____, _____, MEMBR, CALL,  _____, _____, _____, INDEX, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, INC,   DEC,   _____, _____, MUL,   DIV,   REM,   EXPN,  ADD,   SUB,   BSL,
-    BSR,   LESS,  LSEQ,  GRTR,  GREQ,  EQ,    INEQ,  B_AND, B_XOR, B_OR,  AND,   OR,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____,
-]);
-
-precedence!(Precedence12, [
-    _____, _____, _____, _____, MEMBR, CALL,  _____, _____, _____, INDEX, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, INC,   DEC,   _____, _____, MUL,   DIV,   REM,   EXPN,  ADD,   SUB,   BSL,
-    BSR,   LESS,  LSEQ,  GRTR,  GREQ,  EQ,    INEQ,  B_AND, B_XOR, B_OR,  AND,   _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____,
-]);
-
-precedence!(Precedence11, [
-    _____, _____, _____, _____, MEMBR, CALL,  _____, _____, _____, INDEX, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, INC,   DEC,   _____, _____, MUL,   DIV,   REM,   EXPN,  ADD,   SUB,   BSL,
-    BSR,   LESS,  LSEQ,  GRTR,  GREQ,  EQ,    INEQ,  B_AND, B_XOR, B_OR,  _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____,
-]);
-
-precedence!(Precedence10, [
-    _____, _____, _____, _____, MEMBR, CALL,  _____, _____, _____, INDEX, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, INC,   DEC,   _____, _____, MUL,   DIV,   REM,   EXPN,  ADD,   SUB,   BSL,
-    BSR,   LESS,  LSEQ,  GRTR,  GREQ,  _____, _____, B_AND, B_XOR, B_OR,  _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____,
-]);
-
-precedence!(Precedence9, [
-    _____, _____, _____, _____, MEMBR, CALL,  _____, _____, _____, INDEX, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, INC,   DEC,   _____, _____, MUL,   DIV,   REM,   EXPN,  ADD,   SUB,   BSL,
-    BSR,   _____, _____, _____, _____, _____, _____, B_AND, B_XOR, B_OR,  _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____,
-]);
-
-precedence!(Precedence8, [
-    _____, _____, _____, _____, MEMBR, CALL,  _____, _____, _____, INDEX, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, INC,   DEC,   _____, _____, MUL,   DIV,   REM,   EXPN,  ADD,   SUB,   BSL,
-    BSR,   _____, _____, _____, _____, _____, _____, B_AND, B_XOR, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____,
-]);
-
-precedence!(Precedence7, [
-    _____, _____, _____, _____, MEMBR, CALL,  _____, _____, _____, INDEX, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, INC,   DEC,   _____, _____, MUL,   DIV,   REM,   EXPN,  ADD,   SUB,   BSL,
-    BSR,   _____, _____, _____, _____, _____, _____, B_AND, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____,
-]);
-
-precedence!(Precedence6, [
-    _____, _____, _____, _____, MEMBR, CALL,  _____, _____, _____, INDEX, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, INC,   DEC,   _____, _____, MUL,   DIV,   REM,   EXPN,  ADD,   SUB,   BSL,
-    BSR,   _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____,
-]);
-
-precedence!(Precedence5, [
-    _____, _____, _____, _____, MEMBR, CALL,  _____, _____, _____, INDEX, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, INC,   DEC,   _____, _____, MUL,   DIV,   REM,   EXPN,  ADD,   SUB,   _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____,
-]);
-
-precedence!(Precedence4, [
-    _____, _____, _____, _____, MEMBR, CALL,  _____, _____, _____, INDEX, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, INC,   DEC,   _____, _____, MUL,   DIV,   REM,   EXPN,  _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____,
-]);
-
-precedence!(Precedence3, [
-    _____, _____, _____, _____, MEMBR, CALL,  _____, _____, _____, INDEX, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, INC,   DEC,   _____, _____, _____, _____, _____, EXPN,  _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____,
-]);
-
-// TODO: Use in prefix expressions
-precedence!(Precedence2, [
-    _____, _____, _____, _____, MEMBR, CALL,  _____, _____, _____, INDEX, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, INC,   DEC,   _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____, _____,
-    _____, _____,
-]);
-
-const _____: NestedHandler = None;
+impl Precedence for Precedence2 {
+    const LUT: [NestedHandler; Token::SIZE] = lookup! {
+        Token::Accessor => MEMBR,
+        Token::ParenOpen => CALL,
+        Token::BracketOpen => INDEX,
+        Token::OperatorIncrement => INC,
+        Token::OperatorDecrement => DEC,
+        _ => None,
+    };
+}
 
 const CALL: NestedHandler = Some(|par, callee| {
     par.lexer.advance();
@@ -394,7 +495,9 @@ impl<'ast> Parser<'ast> {
     where
         P: Precedence,
     {
-        while let Some(node) = P::get_handler(self.lexer.token).and_then(|handler| handler(self, left)) {
+        // static LUT: [NestedHandler; Token::SIZE] = P::LUT;
+
+        while let Some(node) = P::LUT[self.lexer.token as usize].and_then(|handler| handler(self, left)) {
             left = node;
         }
 

--- a/parser/src/nested.rs
+++ b/parser/src/nested.rs
@@ -179,37 +179,37 @@ macro_rules! binary {
     }
 }
 
-assign!(ASSIGN  => Plain);
-assign!(ASSIGN_ADD => Addition);
-assign!(ASSIGN_SUB => Subtraction);
-assign!(ASSIGN_MUL => Multiplication);
-assign!(ASSIGN_DIV => Division);
-assign!(ASSIGN_REM => Remainder);
-assign!(ASSIGN_BIT_SHIFT_LEFT => BitShiftLeft);
+assign!(ASSIGN                 => Plain);
+assign!(ASSIGN_ADD             => Addition);
+assign!(ASSIGN_SUB             => Subtraction);
+assign!(ASSIGN_MUL             => Multiplication);
+assign!(ASSIGN_DIV             => Division);
+assign!(ASSIGN_REM             => Remainder);
+assign!(ASSIGN_BIT_SHIFT_LEFT  => BitShiftLeft);
 assign!(ASSIGN_BIT_SHIFT_RIGHT => BitShiftRight);
-assign!(ASSIGN_BIT_AND => BitAnd);
-assign!(ASSIGN_BIT_XOR => BitXor);
-assign!(ASSIGN_BIT_OR => BitOr);
+assign!(ASSIGN_BIT_AND         => BitAnd);
+assign!(ASSIGN_BIT_XOR         => BitXor);
+assign!(ASSIGN_BIT_OR          => BitOr);
 
-binary!(LOGICAL_OR    , P13 => LogicalOr);
-binary!(LOGICAL_AND   , P12 => LogicalAnd);
-binary!(EQUALITY    , P11 => Equality);
-binary!(INEQUALITY  , P11 => Inequality);
-binary!(LESSER  , P10 => Lesser);
+binary!(LOGICAL_OR       , P13 => LogicalOr);
+binary!(LOGICAL_AND      , P12 => LogicalAnd);
+binary!(EQUALITY         , P11 => Equality);
+binary!(INEQUALITY       , P11 => Inequality);
+binary!(LESSER           , P10 => Lesser);
 binary!(LESSER_EQUALITY  , P10 => LesserEquals);
-binary!(GREATER  , P10 => Greater);
-binary!(GREATER_EQUALITY  , P10 => GreaterEquals);
-binary!(BIT_OR  , P9  => BitOr);
-binary!(BIT_XOR , P8  => BitXor);
-binary!(BIT_AND , P7  => BitAnd);
+binary!(GREATER          , P10 => Greater);
+binary!(GREATER_EQUALITY , P10 => GreaterEquals);
+binary!(BIT_OR           , P9  => BitOr);
+binary!(BIT_XOR          , P8  => BitXor);
+binary!(BIT_AND          , P7  => BitAnd);
 binary!(BIT_SHIFT_LEFT   , P6  => BitShiftLeft);
-binary!(BIT_SHIFT_RIGHT   , P6  => BitShiftRight);
-binary!(ADD   , P5  => Addition);
-binary!(SUB   , P5  => Subtraction);
-binary!(MUL   , P4  => Multiplication);
-binary!(DIV   , P4  => Division);
-binary!(REMAINDER   , P4  => Remainder);
-binary!(EXPONENT  , P3  => Exponent);
+binary!(BIT_SHIFT_RIGHT  , P6  => BitShiftRight);
+binary!(ADD              , P5  => Addition);
+binary!(SUB              , P5  => Subtraction);
+binary!(MUL              , P4  => Multiplication);
+binary!(DIV              , P4  => Division);
+binary!(REMAINDER        , P4  => Remainder);
+binary!(EXPONENT         , P3  => Exponent);
 
 
 impl<'ast> Parser<'ast> {

--- a/parser/src/statement.rs
+++ b/parser/src/statement.rs
@@ -1,7 +1,7 @@
 use toolshed::list::{List, GrowableList, ListBuilder};
 
 use ast::*;
-use {Parser, TopPrecedence, StatementTypeNameContext};
+use {Parser, TOP, StatementTypeNameContext};
 use lexer::Token;
 
 /// A trait that allows for extra statements to be parsed in a specific context.
@@ -146,7 +146,7 @@ impl<'ast> Parser<'ast> {
 
         self.expect(Token::ParenOpen);
 
-        let test = expect!(self, self.expression::<TopPrecedence>());
+        let test = expect!(self, self.expression(TOP));
 
         self.expect(Token::ParenClose);
 
@@ -180,7 +180,7 @@ impl<'ast> Parser<'ast> {
 
         self.expect(Token::ParenOpen);
 
-        let test = expect!(self, self.expression::<TopPrecedence>());
+        let test = expect!(self, self.expression(TOP));
 
         self.expect(Token::ParenClose);
 
@@ -206,11 +206,11 @@ impl<'ast> Parser<'ast> {
             self.expect(Token::Semicolon);
         }
 
-        let test = self.expression::<TopPrecedence>();
+        let test = self.expression(TOP);
 
         self.expect(Token::Semicolon);
 
-        let update = self.expression::<TopPrecedence>();
+        let update = self.expression(TOP);
 
         self.expect(Token::ParenClose);
 
@@ -234,7 +234,7 @@ impl<'ast> Parser<'ast> {
         self.expect(Token::KeywordWhile);
         self.expect(Token::ParenOpen);
 
-        let test = expect!(self, self.expression::<TopPrecedence>());
+        let test = expect!(self, self.expression(TOP));
 
         self.expect(Token::ParenClose);
 
@@ -248,7 +248,7 @@ impl<'ast> Parser<'ast> {
 
     fn return_statement(&mut self) -> Option<StatementNode<'ast>> {
         let start = self.start_then_advance();
-        let value = self.expression::<TopPrecedence>();
+        let value = self.expression(TOP);
         let end   = self.expect_end(Token::Semicolon);
 
         self.node_at(start, end, ReturnStatement {
@@ -276,7 +276,7 @@ impl<'ast> Parser<'ast> {
     where
         S: From<ExpressionNode<'ast>> + Copy,
     {
-        let expression = self.expression::<TopPrecedence>()?;
+        let expression = self.expression(TOP)?;
         let end        = self.expect_end(Token::Semicolon);
 
         self.node_at(expression.start, end, expression)
@@ -292,7 +292,7 @@ impl<'ast> Parser<'ast> {
         let init;
 
         if self.allow(Token::Assign) {
-            init = self.expression::<TopPrecedence>();
+            init = self.expression(TOP);
 
             if init.is_none() {
                 self.error();
@@ -324,7 +324,7 @@ impl<'ast> Parser<'ast> {
 
         self.expect(Token::Assign);
 
-        let init = expect!(self, self.expression::<TopPrecedence>());
+        let init = expect!(self, self.expression(TOP));
         let end  = self.expect_end(Token::Semicolon);
 
         self.node_at(start, end, InferredDefinitionStatement {

--- a/parser/src/statement.rs
+++ b/parser/src/statement.rs
@@ -85,10 +85,6 @@ impl<'ast> Parser<'ast> {
             Token::KeywordAssembly => self.inline_assembly_statement(),
             Token::DeclarationVar  => self.inferred_definition_statement(),
 
-            // _ => match self.expression_statement() {
-            //     None => self.variable_definition_statement(),
-            //     node => node,
-            // }
             _ => match self.variable_definition_statement() {
                 None => self.expression_statement(),
                 node => node,


### PR DESCRIPTION
+ Updated `Logos` to latest version.
+ Replaced all lookup tables in `nested.rs` with a single table:
    + Instead of `Option<fn()>` the handlers are a tuple of `(u8, fn())` (using some newtypes), where the `u8` stores the precedence. Instead of unwrapping the `Option` we compare precedence, the net effect on performance is barely noticeable, and we end up with less code and less generics (= faster compile times).